### PR TITLE
[release-2.9] [ACM-4380] Fix linting issues reported by SonarCloud.

### DIFF
--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -23,13 +23,14 @@ import (
 	"strings"
 	"text/template"
 
-	"github.com/brancz/kube-rbac-proxy/pkg/authn"
-	"github.com/brancz/kube-rbac-proxy/pkg/authz"
 	"k8s.io/apiserver/pkg/authentication/authenticator"
 	"k8s.io/apiserver/pkg/authentication/user"
 	"k8s.io/apiserver/pkg/authorization/authorizer"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/klog/v2"
+
+	"github.com/brancz/kube-rbac-proxy/pkg/authn"
+	"github.com/brancz/kube-rbac-proxy/pkg/authz"
 )
 
 // Config holds proxy authorization and authentication settings
@@ -259,6 +260,6 @@ func (c *Config) DeepCopy() *Config {
 func templateWithValue(templateString, value string) string {
 	tmpl, _ := template.New("valueTemplate").Parse(templateString)
 	out := bytes.NewBuffer(nil)
-	tmpl.Execute(out, struct{ Value string }{Value: value})
+	_ = tmpl.Execute(out, struct{ Value string }{Value: value})
 	return out.String()
 }

--- a/test/kubetest/kubernetes.go
+++ b/test/kubetest/kubernetes.go
@@ -41,7 +41,7 @@ import (
 func CreatedManifests(client kubernetes.Interface, paths ...string) Setup {
 	return func(ctx *ScenarioContext) error {
 		for _, path := range paths {
-			content, err := ioutil.ReadFile(path)
+			content, err := ioutil.ReadFile(path) // #nosec: G304 -- This is intended and unavoidable.
 			if err != nil {
 				return err
 			}
@@ -181,7 +181,7 @@ func dumpLogs(client kubernetes.Interface, ctx *ScenarioContext, opts metav1.Lis
 				return
 			}
 
-			io.Copy(os.Stdout, stream)
+			_, _ = io.Copy(os.Stdout, stream)
 		}
 	}
 }

--- a/transport.go
+++ b/transport.go
@@ -32,7 +32,7 @@ func initTransport(upstreamCAFile string) (http.RoundTripper, error) {
 		return http.DefaultTransport, nil
 	}
 
-	rootPEM, err := ioutil.ReadFile(upstreamCAFile)
+	rootPEM, err := ioutil.ReadFile(upstreamCAFile) // #nosec: G304 -- This is intended and unavoidable.
 	if err != nil {
 		return nil, fmt.Errorf("error reading upstream CA file: %v", err)
 	}
@@ -54,7 +54,7 @@ func initTransport(upstreamCAFile string) (http.RoundTripper, error) {
 		IdleConnTimeout:       90 * time.Second,
 		TLSHandshakeTimeout:   10 * time.Second,
 		ExpectContinueTimeout: 1 * time.Second,
-		TLSClientConfig:       &tls.Config{RootCAs: roots},
+		TLSClientConfig:       &tls.Config{RootCAs: roots, MinVersion: tls.VersionTLS12},
 	}
 
 	return transport, nil


### PR DESCRIPTION
[ACM-4380](https://issues.redhat.com/browse/ACM-4380)

All of them coming from the `gosec` tool.

A new scan shows:

```
Summary:
  Gosec  : 2.18.2
  Files  : 13
  Lines  : 2401
  Nosec  : 2
  Issues : 0
```