### PR TITLE
Use a build flag to run e2e tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -83,7 +83,7 @@ test-unit:
 	go test -v -race -count=1 $(PKGS)
 
 test-e2e:
-	go test -timeout 55m -v ./test/e2e/ $(TEST_RUN_ARGS) --kubeconfig=$(KUBECONFIG)
+	go test -tags e2e -timeout 55m -v ./test/e2e/ $(TEST_RUN_ARGS) --kubeconfig=$(KUBECONFIG)
 
 generate: build $(EMBEDMD_BINARY)
 	@echo ">> generating examples"

--- a/test/e2e/basics.go
+++ b/test/e2e/basics.go
@@ -1,3 +1,6 @@
+//go:build e2e
+// +build e2e
+
 /*
 Copyright 2017 Frederic Branczyk All rights reserved.
 
@@ -20,8 +23,9 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/brancz/kube-rbac-proxy/test/kubetest"
 	"k8s.io/client-go/kubernetes"
+
+	"github.com/brancz/kube-rbac-proxy/test/kubetest"
 )
 
 func testBasics(s *kubetest.Suite) kubetest.TestSuite {

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -1,3 +1,6 @@
+//go:build e2e
+// +build e2e
+
 /*
 Copyright 2017 Frederic Branczyk All rights reserved.
 

--- a/test/e2e/tls.go
+++ b/test/e2e/tls.go
@@ -1,3 +1,6 @@
+//go:build e2e
+// +build e2e
+
 /*
 Copyright 2021 Frederic Branczyk All rights reserved.
 


### PR DESCRIPTION
The build harness is running tests with go test [...] ./... (see the targets [sonar/go/prow](https://github.com/stolostron/build-harness-extensions/blob/2ce1b35c0098a407dda410ea9dcd66a7263b68b7/modules/sonar/Makefile#L30C51-L30C51) and [sonar/go](https://github.com/stolostron/build-harness-extensions/blob/2ce1b35c0098a407dda410ea9dcd66a7263b68b7/modules/sonar/Makefile#L10), among others). This ends up building and running e2e tests which are supposed to be executed only through the script in tests/e2e.sh.

This PR:

* Puts the e2e test files behind a build flag named e2e.
* Updates the `test-e2e` makefile target to use the `e2e` flag.

This should clear all the remaining SonarCloud complaints on the project, which is about a failing test.