### PR TITLE
RHTAP prep for release-2.11

### DIFF
--- a/Containerfile.operator
+++ b/Containerfile.operator
@@ -1,0 +1,16 @@
+# Copyright Contributors to the Open Cluster Management project
+# Licensed under the Apache License 2.0
+
+FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_8_1.20 AS builder
+
+WORKDIR /workspace
+COPY . .
+RUN CGO_ENABLED=1 GOFLAGS="" go build --installsuffix cgo
+
+FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
+
+COPY --from=builder /workspace/kube-rbac-proxy /usr/local/bin/kube-rbac-proxy
+EXPOSE 8080
+USER 65532:65532
+
+ENTRYPOINT ["/usr/local/bin/kube-rbac-proxy"]


### PR DESCRIPTION
Required by [ACM-10834](https://issues.redhat.com/browse/ACM-10834)

Add docker file for RHTAP builds (with a new base image) to release-2.11 builds

cc: @Kyl-Bempah 