### PR TITLE
Konflux: Correctly configure prefetch input

### DIFF
--- a/.tekton/kube-rbac-proxy-acm-213-pull-request.yaml
+++ b/.tekton/kube-rbac-proxy-acm-213-pull-request.yaml
@@ -35,6 +35,8 @@ spec:
     value: .
   - name: hermetic
     value: true
+  - name: prefetch-input
+    value: '{"type": "gomod", "path": "."}'
   pipelineSpec:
     description: |
       This pipeline is ideal for building multi-arch container images from a Containerfile while maintaining trust after pipeline customization.


### PR DESCRIPTION
This ensures go dependencies are being pulled correctly before the hermetic build step (which has no internet connectivity, hence currently fails during build as it cannot fetch dependencies).