### PR TITLE
chore(KONFLUX-6210): fix and set name and cpe label for kube-rbac-proxy-acm-214

### DIFF
--- a/Containerfile.operator
+++ b/Containerfile.operator
@@ -16,7 +16,8 @@ USER 65532:65532
 ENTRYPOINT ["/usr/local/bin/kube-rbac-proxy"]
 
 LABEL com.redhat.component="kube-rbac-proxy" \
-name="kube-rbac-proxy" \
+name="rhacm2/kube-rbac-proxy-rhel9" \
+cpe="cpe:/a:redhat:acm:2.14::el9" \
 summary="kube-rbac-proxy" \
 io.openshift.expose-services="" \
 io.openshift.tags="data,images" \
@@ -24,4 +25,3 @@ io.k8s.display-name="kube-rbac-proxy" \
 maintainer="" \
 description="kube-rbac-proxy" \
 io.k8s.description="kube-rbac-proxy"
-


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini
