### PR TITLE
[backplane-2.8] Add CPE labels for container images

### DIFF
--- a/Containerfile.operator
+++ b/Containerfile.operator
@@ -16,7 +16,8 @@ USER 65532:65532
 ENTRYPOINT ["/usr/local/bin/kube-rbac-proxy"]
 
 LABEL com.redhat.component="kube-rbac-proxy" \
-name="kube-rbac-proxy" \
+name="multicluster-engine/kube-rbac-proxy-mce-rhel9" \
+cpe="cpe:/a:redhat:multicluster_engine:2.8::el9" \
 summary="kube-rbac-proxy" \
 io.openshift.expose-services="" \
 io.openshift.tags="data,images" \


### PR DESCRIPTION
Related: [ACM-28713](https://issues.redhat.com/browse/ACM-28713)