### PR TITLE
fix(cve): CVE-2026-32282 - archive/tar (Go stdlib)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/brancz/kube-rbac-proxy
 
-go 1.24.0
+go 1.25.9
 
 require (
 	github.com/ghodss/yaml v1.0.0


### PR DESCRIPTION
## Summary

This PR fixes **CVE-2026-32282** (GO-2026-4864) by updating the Go version from 1.24.0 to 1.25.9.

### CVE Details
- **CVE ID**: CVE-2026-32282
- **Go Vuln ID**: GO-2026-4864
- **Package**: internal/syscall/unix (Go stdlib)
- **Severity**: Moderate
- **Impact**: TOCTOU permits root escape on Linux via Root.Chmod in os
- **Vulnerable versions**: Go < 1.25.9
- **Fixed version**: Go 1.25.9
- **Platforms**: Linux only

### Changes
- Updated `go.mod`: `go 1.24.0` → `go 1.25.9`
- Updated `go.sum` via `go mod tidy`

### Test Results

**Status**: ✅ PASSED
**Test command**: `go test ./...`

```
ok   github.com/brancz/kube-rbac-proxy          0.031s
ok   github.com/brancz/kube-rbac-proxy/pkg/proxy 0.033s
ok   github.com/brancz/kube-rbac-proxy/pkg/tls   1.742s
```

### Post-fix Verification
govulncheck reports 0 vulnerabilities after fix.

### Breaking Changes
- Go minimum version bumped from 1.24.0 to 1.25.9
- No Go 1.24.x patch exists — Go 1.25.9 is the minimum fix version
- Builder images already use Go 1.25

### Risk Assessment
| Factor | Assessment |
|--------|-----------|
| Change scope | Low — go.mod version bump only |
| Breaking risk | Low — builders already on Go 1.25 |
| Test coverage | Good — all tests pass |

Resolves: ACM-32777

---

🤖 Generated by CVE Fixer Workflow
<!-- cve-fixer-workflow -->