### PR TITLE
fix(cve): CVE-2026-32282 - archive/tar (Go stdlib)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/brancz/kube-rbac-proxy
 
-go 1.24.0
+go 1.25.9
 
 require (
 	github.com/ghodss/yaml v1.0.0


### PR DESCRIPTION
## Summary
Fixes **CVE-2026-32282** (GO-2026-4864) — TOCTOU root escape via Root.Chmod. Updates Go from 1.24.0 to 1.25.9.

### CVE Details
- **CVE ID**: CVE-2026-32282 | **Go Vuln ID**: GO-2026-4864
- **Package**: internal/syscall/unix (Go stdlib) | **Fixed in**: Go 1.25.9

### Test Results
**Status**: ✅ PASSED — `go test ./...` all pass

### Risk Assessment
Low — go.mod version bump only, builders already on Go 1.25

Resolves: ACM-32773

🤖 Generated by CVE Fixer Workflow
<!-- cve-fixer-workflow -->