### PR TITLE
fix(dockerfile): upgrade runtime base image from ubi8 to ubi9

### DIFF
--- a/Containerfile.operator
+++ b/Containerfile.operator
@@ -7,7 +7,7 @@ WORKDIR /workspace
 COPY . .
 RUN CGO_ENABLED=1 GOFLAGS="" go build --installsuffix cgo
 
-FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
+FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
 
 COPY --from=builder /workspace/kube-rbac-proxy /usr/local/bin/kube-rbac-proxy
 EXPOSE 8080

--- a/Dockerfile.prow
+++ b/Dockerfile.prow
@@ -6,7 +6,7 @@ WORKDIR /workspace
 COPY . .
 RUN go build --installsuffix cgo
 
-FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
+FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
 
 COPY --from=builder /workspace/kube-rbac-proxy /usr/local/bin/kube-rbac-proxy
 EXPOSE 8080


### PR DESCRIPTION
## Summary

Fixes a GLIBC version mismatch that causes kube-rbac-proxy to crash at startup in ACM 2.11.10:

```
/usr/local/bin/kube-rbac-proxy: /lib64/libc.so.6: version `GLIBC_2.32' not found
/usr/local/bin/kube-rbac-proxy: /lib64/libc.so.6: version `GLIBC_2.34' not found
```

## Root Cause

The `go1.25-linux` and `rhel_9_1.25` builder images are RHEL 9-based and produce CGO binaries requiring GLIBC 2.32+. The runtime base image was left as `ubi8/ubi-minimal` (GLIBC 2.28 max) when the builder was upgraded to Go 1.25, causing the crash on startup.

## Changes

- `Dockerfile.prow`: `ubi8/ubi-minimal:latest` → `ubi9/ubi-minimal:latest`
- `Containerfile.operator`: `ubi8/ubi-minimal:latest` → `ubi9/ubi-minimal:latest`

This matches what `backplane-2.9`, `backplane-2.10`, and `backplane-2.11` branches already do correctly.

## Test Plan

- [ ] Rebuild the kube-rbac-proxy image using the updated Dockerfile.prow
- [ ] Deploy to an ACM 2.11.10 environment and verify `kube-rbac-proxy` starts without GLIBC errors
- [ ] Confirm `oc logs <pod> kube-rbac-proxy` shows no `version not found` errors

Fixes ACM-32741