### PR TITLE
Security: Fix CVE-2026-32282 (os.Root.Chmod symlink escape via TOCTOU)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/brancz/kube-rbac-proxy
 
-go 1.24.0
+go 1.25.9
 
 require (
 	github.com/ghodss/yaml v1.0.0


### PR DESCRIPTION
## Summary

This PR fixes **CVE-2026-32282** by updating the Go toolchain from 1.24.0 to 1.25.9 in go.mod.

### CVE Details

- **CVE ID**: CVE-2026-32282
- **GoVuln ID**: GO-2026-4864
- **Package**: Go standard library (`os`, `internal/syscall/unix`)
- **Impact**: TOCTOU race condition in `os.Root.Chmod` allows symlink to escape container root on Linux
- **Fixed version**: go1.25.9
- **Jira Issues**: ACM-33482

### Changes

| File | Change |
|------|--------|
| `go.mod` | `go 1.24.0` → `go 1.25.9` |

### Test Results

**Status**: ✅ PASSED — `go test ./...` all pass with go1.25.9

### Post-fix Verification

govulncheck with GOTOOLCHAIN=go1.25.9 confirms GO-2026-4864 no longer detected. ✅

---
Resolves: ACM-33482

🤖 Generated by CVE Fixer Workflow
<!-- cve-fixer-workflow -->