### PR TITLE
Add Dockerfile.art for ART/Brew build migration

### DIFF
--- a/Dockerfile.art
+++ b/Dockerfile.art
@@ -1,0 +1,31 @@
+# Copyright Contributors to the Open Cluster Management project
+# Licensed under the Apache License 2.0
+
+FROM registry-proxy.engineering.redhat.com/rh-osbs/openshift-golang-builder:v1.25.8 AS builder
+
+WORKDIR /workspace
+COPY . .
+RUN CGO_ENABLED=1 GOFLAGS="" GOEXPERIMENT=strictfipsruntime go build --installsuffix cgo
+
+FROM registry-proxy.engineering.redhat.com/ubi9/ubi-minimal:latest
+
+ARG IMAGE_NAME="kube-rbac-proxy"
+ARG CPE_LABEL=""
+
+COPY --from=builder /workspace/kube-rbac-proxy /usr/local/bin/kube-rbac-proxy
+EXPOSE 8080
+USER 65532:65532
+
+ENTRYPOINT ["/usr/local/bin/kube-rbac-proxy"]
+
+LABEL com.redhat.component="kube-rbac-proxy" \
+name="${IMAGE_NAME}" \
+cpe="${CPE_LABEL}" \
+summary="kube-rbac-proxy" \
+io.openshift.expose-services="" \
+io.openshift.tags="data,images" \
+io.k8s.display-name="kube-rbac-proxy" \
+maintainer="" \
+description="kube-rbac-proxy" \
+io.k8s.description="kube-rbac-proxy"
+


### PR DESCRIPTION
HYPBLD-847: ACM 2.16: Create Dockerfile.art + ocp-build-data config
https://redhat.atlassian.net/browse/HYPBLD-847

Create the build configuration required for ART to build ACM 2.16 components.

Dockerfile.art files (50 repos):                                                                     
- Create Dockerfile.art in each ACM repo on release-2.16 branch                                      
- Use existing Dockerfile.rhtap as starting point                                                    
- Change registry to registry-proxy.engineering.redhat.com
- Add FIPS flags (GOEXPERIMENT=strictfipsruntime, CGO_ENABLED=1)                                     
Note: multiclusterhub-operator uses brew.registry — needs manual FROM line conversion              

Signed-off-by: Brian Smith (briansmi@redhat.com)