### PR TITLE
Add FIPS build flags to Dockerfile

### DIFF
--- a/Containerfile.operator
+++ b/Containerfile.operator
@@ -5,7 +5,7 @@ FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.25 AS bui
 
 WORKDIR /workspace
 COPY . .
-RUN CGO_ENABLED=1 GOFLAGS="" go build --installsuffix cgo
+RUN CGO_ENABLED=1 GOEXPERIMENT=strictfipsruntime GOFLAGS="" go build --installsuffix cgo
 
 FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
 


### PR DESCRIPTION
Add CGO_ENABLED=1 and GOEXPERIMENT=strictfipsruntime to go build, make, and promu build lines for FIPS compliance.

JIRA: HYPBLD-847