### PR TITLE
Add FIPS build flags to Konflux Containerfile

### DIFF
--- a/Containerfile.operator
+++ b/Containerfile.operator
@@ -5,7 +5,7 @@ FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.25 AS bui
 
 WORKDIR /workspace
 COPY . .
-RUN CGO_ENABLED=1 GOFLAGS="" go build --installsuffix cgo
+RUN CGO_ENABLED=1 GOEXPERIMENT=strictfipsruntime GOFLAGS="" go build --installsuffix cgo
 
 FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
 


### PR DESCRIPTION
## Summary

- Adds `GOEXPERIMENT=strictfipsruntime` to the Konflux `Containerfile.operator` build (`CGO_ENABLED=1` was already set).
- Addresses [HYPBLD-844](https://redhat.atlassian.net/browse/HYPBLD-844) FIPS build flag requirements.

This pull request was created by Cursor.

## Test plan

- [ ] Verify Konflux/RHTAP pipeline build succeeds for kube-rbac-proxy-mce-211
- [ ] Confirm built binaries link against FIPS crypto libraries as expected


Made with [Cursor](https://cursor.com)

[HYPBLD-844]: https://redhat.atlassian.net/browse/HYPBLD-844?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ